### PR TITLE
Fix fee and salary payment for individuals

### DIFF
--- a/backend/routes/feeRoute.js
+++ b/backend/routes/feeRoute.js
@@ -7,7 +7,8 @@ import {
   getStudentFeeRecords, 
   updateFeeRecord, 
   deleteFeeRecord, 
-  getFeeStatistics 
+  getFeeStatistics,
+  bulkUpdateFeePaymentStatus
 } from "../controllers/feeController.js";
 import { protectedRoute } from "../middlewares/authorization.js";
 
@@ -30,6 +31,9 @@ router.get("/student/:studentId", protectedRoute, getStudentFeeRecords);
 
 // Update fee record (mark as paid/unpaid, update note)
 router.put("/update/:feeId", protectedRoute, updateFeeRecord);
+
+// Bulk update fee payment status for multiple records
+router.put("/bulk-update-payment", protectedRoute, bulkUpdateFeePaymentStatus);
 
 // Delete fee record
 router.delete("/delete/:feeId", protectedRoute, deleteFeeRecord);

--- a/backend/routes/salaryRoute.js
+++ b/backend/routes/salaryRoute.js
@@ -7,7 +7,8 @@ import {
   updateSalaryRecord, 
   deleteSalaryRecord, 
   getSalaryStatistics,
-  getAllTeachers
+  getAllTeachers,
+  bulkUpdateSalaryPaymentStatus
 } from "../controllers/salaryController.js";
 import { protectedRoute } from "../middlewares/authorization.js";
 
@@ -30,6 +31,9 @@ router.get("/teacher/:teacherId", protectedRoute, getTeacherSalaryRecords);
 
 // Update salary record (mark as paid/unpaid, update amounts)
 router.put("/update/:salaryId", protectedRoute, updateSalaryRecord);
+
+// Bulk update salary payment status for multiple records
+router.put("/bulk-update-payment", protectedRoute, bulkUpdateSalaryPaymentStatus);
 
 // Delete salary record
 router.delete("/delete/:salaryId", protectedRoute, deleteSalaryRecord);


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Implement individual and bulk payment status updates for student fees and teacher salaries.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
This change addresses the issue where the system incorrectly assumed all students/teachers were paid, lacking granular control. Users can now select individual or multiple students/teachers to mark their payment status (paid/unpaid) accurately, improving fee and salary management.

---
<a href="https://cursor.com/background-agent?bcId=bc-7ba156df-218d-482c-adf8-c79f8bc928f9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7ba156df-218d-482c-adf8-c79f8bc928f9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>